### PR TITLE
Update to last Monero master before v0.15 branch

### DIFF
--- a/crypto/hash-ops.h
+++ b/crypto/hash-ops.h
@@ -87,3 +87,11 @@ void hash_extra_jh(const void *data, size_t length, char *hash);
 void hash_extra_skein(const void *data, size_t length, char *hash);
 
 void tree_hash(const char (*hashes)[HASH_SIZE], size_t count, char *root_hash);
+
+#define RX_BLOCK_VERSION	12
+void rx_slow_hash_allocate_state(void);
+void rx_slow_hash_free_state(void);
+uint64_t rx_seedheight(const uint64_t height);
+void rx_seedheights(const uint64_t height, uint64_t *seed_height, uint64_t *next_height);
+void rx_slow_hash(const uint64_t mainheight, const uint64_t seedheight, const char *seedhash, const void *data, size_t length, char *hash, int miners, int is_alt);
+void rx_reorg(const uint64_t split_height);

--- a/crypto/hash.h
+++ b/crypto/hash.h
@@ -32,7 +32,6 @@
 
 #include <stddef.h>
 #include <iostream>
-#include <boost/utility/value_init.hpp>
 
 #include "common/pod-class.h"
 #include "generic-ops.h"
@@ -90,8 +89,8 @@ namespace crypto {
     epee::to_hex::formatted(o, epee::as_byte_span(v)); return o;
   }
 
-  const static crypto::hash null_hash = boost::value_initialized<crypto::hash>();
-  const static crypto::hash8 null_hash8 = boost::value_initialized<crypto::hash8>();
+  constexpr static crypto::hash null_hash = {};
+  constexpr static crypto::hash8 null_hash8 = {};
 }
 
 CRYPTO_MAKE_HASHABLE(hash)

--- a/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -81,53 +81,6 @@ namespace cryptonote {
     return CRYPTONOTE_MAX_TX_SIZE;
   }
   //-----------------------------------------------------------------------------------------------
-  bool get_block_reward(size_t median_weight, size_t current_block_weight, uint64_t already_generated_coins, uint64_t &reward, uint8_t version) {
-    static_assert(DIFFICULTY_TARGET_V2%60==0&&DIFFICULTY_TARGET_V1%60==0,"difficulty targets must be a multiple of 60");
-    const int target = version < 2 ? DIFFICULTY_TARGET_V1 : DIFFICULTY_TARGET_V2;
-    const int target_minutes = target / 60;
-    const int emission_speed_factor = EMISSION_SPEED_FACTOR_PER_MINUTE - (target_minutes-1);
-
-    uint64_t base_reward = (MONEY_SUPPLY - already_generated_coins) >> emission_speed_factor;
-    if (base_reward < FINAL_SUBSIDY_PER_MINUTE*target_minutes)
-    {
-      base_reward = FINAL_SUBSIDY_PER_MINUTE*target_minutes;
-    }
-
-    uint64_t full_reward_zone = get_min_block_weight(version);
-
-    //make it soft
-    if (median_weight < full_reward_zone) {
-      median_weight = full_reward_zone;
-    }
-
-    if (current_block_weight <= median_weight) {
-      reward = base_reward;
-      return true;
-    }
-
-    if(current_block_weight > 2 * median_weight) {
-      MERROR("Block cumulative weight is too big: " << current_block_weight << ", expected less than " << 2 * median_weight);
-      return false;
-    }
-
-    uint64_t product_hi;
-    // BUGFIX: 32-bit saturation bug (e.g. ARM7), the result was being
-    // treated as 32-bit by default.
-    uint64_t multiplicand = 2 * median_weight - current_block_weight;
-    multiplicand *= current_block_weight;
-    uint64_t product_lo = mul128(base_reward, multiplicand, &product_hi);
-
-    uint64_t reward_hi;
-    uint64_t reward_lo;
-    div128_64(product_hi, product_lo, median_weight, &reward_hi, &reward_lo, NULL, NULL);
-    div128_64(reward_hi, reward_lo, median_weight, &reward_hi, &reward_lo, NULL, NULL);
-    assert(0 == reward_hi);
-    assert(reward_lo < base_reward);
-
-    reward = reward_lo;
-    return true;
-  }
-  //------------------------------------------------------------------------------------
   uint8_t get_account_address_checksum(const public_address_outer_blob& bl)
   {
     const unsigned char* pbuf = reinterpret_cast<const unsigned char*>(&bl);

--- a/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -110,9 +110,6 @@ namespace cryptonote {
       return false;
     }
 
-    assert(median_weight < std::numeric_limits<uint32_t>::max());
-    assert(current_block_weight < std::numeric_limits<uint32_t>::max());
-
     uint64_t product_hi;
     // BUGFIX: 32-bit saturation bug (e.g. ARM7), the result was being
     // treated as 32-bit by default.
@@ -122,8 +119,8 @@ namespace cryptonote {
 
     uint64_t reward_hi;
     uint64_t reward_lo;
-    div128_32(product_hi, product_lo, static_cast<uint32_t>(median_weight), &reward_hi, &reward_lo);
-    div128_32(reward_hi, reward_lo, static_cast<uint32_t>(median_weight), &reward_hi, &reward_lo);
+    div128_64(product_hi, product_lo, median_weight, &reward_hi, &reward_lo, NULL, NULL);
+    div128_64(reward_hi, reward_lo, median_weight, &reward_hi, &reward_lo, NULL, NULL);
     assert(0 == reward_hi);
     assert(reward_lo < base_reward);
 

--- a/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/cryptonote_basic/cryptonote_format_utils.cpp
@@ -103,6 +103,26 @@ namespace cryptonote
       ge_p1p1_to_p3(&A2, &tmp3);
       ge_p3_tobytes(&AB, &A2);
   }
+
+  uint64_t get_transaction_weight_clawback(const transaction &tx, size_t n_padded_outputs)
+  {
+    const rct::rctSig &rv = tx.rct_signatures;
+    const uint64_t bp_base = 368;
+    const size_t n_outputs = tx.vout.size();
+    if (n_padded_outputs <= 2)
+      return 0;
+    size_t nlr = 0;
+    while ((1u << nlr) < n_padded_outputs)
+      ++nlr;
+    nlr += 6;
+    const size_t bp_size = 32 * (9 + 2 * nlr);
+    CHECK_AND_ASSERT_THROW_MES_L1(n_outputs <= BULLETPROOF_MAX_OUTPUTS, "maximum number of outputs is " + std::to_string(BULLETPROOF_MAX_OUTPUTS) + " per transaction");
+    CHECK_AND_ASSERT_THROW_MES_L1(bp_base * n_padded_outputs >= bp_size, "Invalid bulletproof clawback: bp_base " + std::to_string(bp_base) + ", n_padded_outputs "
+        + std::to_string(n_padded_outputs) + ", bp_size " + std::to_string(bp_size));
+    const uint64_t bp_clawback = (bp_base * n_padded_outputs - bp_size) * 4 / 5;
+    return bp_clawback;
+  }
+  //---------------------------------------------------------------
 }
 
 namespace cryptonote
@@ -386,25 +406,59 @@ namespace cryptonote
   //---------------------------------------------------------------
   uint64_t get_transaction_weight(const transaction &tx, size_t blob_size)
   {
+    CHECK_AND_ASSERT_MES(!tx.pruned, std::numeric_limits<uint64_t>::max(), "get_transaction_weight does not support pruned txes");
     if (tx.version < 2)
       return blob_size;
     const rct::rctSig &rv = tx.rct_signatures;
     if (!rct::is_rct_bulletproof(rv.type))
       return blob_size;
-    const size_t n_outputs = tx.vout.size();
-    if (n_outputs <= 2)
-      return blob_size;
-    const uint64_t bp_base = 368;
     const size_t n_padded_outputs = rct::n_bulletproof_max_amounts(rv.p.bulletproofs);
-    size_t nlr = 0;
-    for (const auto &bp: rv.p.bulletproofs)
-      nlr += bp.L.size() * 2;
-    const size_t bp_size = 32 * (9 + nlr);
-    CHECK_AND_ASSERT_THROW_MES_L1(n_outputs <= BULLETPROOF_MAX_OUTPUTS, "maximum number of outputs is " + std::to_string(BULLETPROOF_MAX_OUTPUTS) + " per transaction");
-    CHECK_AND_ASSERT_THROW_MES_L1(bp_base * n_padded_outputs >= bp_size, "Invalid bulletproof clawback");
-    const uint64_t bp_clawback = (bp_base * n_padded_outputs - bp_size) * 4 / 5;
+    uint64_t bp_clawback = get_transaction_weight_clawback(tx, n_padded_outputs);
     CHECK_AND_ASSERT_THROW_MES_L1(bp_clawback <= std::numeric_limits<uint64_t>::max() - blob_size, "Weight overflow");
     return blob_size + bp_clawback;
+  }
+  //---------------------------------------------------------------
+  uint64_t get_pruned_transaction_weight(const transaction &tx)
+  {
+    CHECK_AND_ASSERT_MES(tx.pruned, std::numeric_limits<uint64_t>::max(), "get_pruned_transaction_weight does not support non pruned txes");
+    CHECK_AND_ASSERT_MES(tx.version >= 2, std::numeric_limits<uint64_t>::max(), "get_pruned_transaction_weight does not support v1 txes");
+    CHECK_AND_ASSERT_MES(tx.rct_signatures.type >= rct::RCTTypeBulletproof2,
+        std::numeric_limits<uint64_t>::max(), "get_pruned_transaction_weight does not support older range proof types");
+    CHECK_AND_ASSERT_MES(!tx.vin.empty(), std::numeric_limits<uint64_t>::max(), "empty vin");
+    CHECK_AND_ASSERT_MES(tx.vin[0].type() == typeid(cryptonote::txin_to_key), std::numeric_limits<uint64_t>::max(), "empty vin");
+
+    // get pruned data size
+    std::ostringstream s;
+    binary_archive<true> a(s);
+    ::serialization::serialize(a, const_cast<transaction&>(tx));
+    uint64_t weight = s.str().size(), extra;
+
+    // nbps (technically varint)
+    weight += 1;
+
+    // calculate deterministic bulletproofs size (assumes canonical BP format)
+    size_t nrl = 0, n_padded_outputs;
+    while ((n_padded_outputs = (1u << nrl)) < tx.vout.size())
+      ++nrl;
+    nrl += 6;
+    extra = 32 * (9 + 2 * nrl) + 2;
+    weight += extra;
+
+    // calculate deterministic MLSAG data size
+    const size_t ring_size = boost::get<cryptonote::txin_to_key>(tx.vin[0]).key_offsets.size();
+    extra = tx.vin.size() * (ring_size * (1 + 1) * 32 + 32 /* cc */);
+    weight += extra;
+
+    // calculate deterministic pseudoOuts size
+    extra =  32 * (tx.vin.size());
+    weight += extra;
+
+    // clawback
+    uint64_t bp_clawback = get_transaction_weight_clawback(tx, n_padded_outputs);
+    CHECK_AND_ASSERT_THROW_MES_L1(bp_clawback <= std::numeric_limits<uint64_t>::max() - weight, "Weight overflow");
+    weight += bp_clawback;
+
+    return weight;
   }
   //---------------------------------------------------------------
   uint64_t get_transaction_weight(const transaction &tx)
@@ -1011,7 +1065,19 @@ namespace cryptonote
   crypto::hash get_transaction_prunable_hash(const transaction& t, const cryptonote::blobdata *blobdata)
   {
     crypto::hash res;
+    if (t.is_prunable_hash_valid())
+    {
+#ifdef ENABLE_HASH_CASH_INTEGRITY_CHECK
+      CHECK_AND_ASSERT_THROW_MES(!calculate_transaction_prunable_hash(t, blobdata, res) || t.hash == res, "tx hash cash integrity failure");
+#endif
+      res = t.prunable_hash;
+      ++tx_hashes_cached_count;
+      return res;
+    }
+
+    ++tx_hashes_calculated_count;
     CHECK_AND_ASSERT_THROW_MES(calculate_transaction_prunable_hash(t, blobdata, res), "Failed to calculate tx prunable hash");
+    t.set_prunable_hash(res);
     return res;
   }
   //---------------------------------------------------------------
@@ -1047,11 +1113,14 @@ namespace cryptonote
 
     // the tx hash is the hash of the 3 hashes
     crypto::hash res = cn_fast_hash(hashes, sizeof(hashes));
+    t.set_hash(res);
     return res;
   }
   //---------------------------------------------------------------
   bool calculate_transaction_hash(const transaction& t, crypto::hash& res, size_t* blob_size)
   {
+    CHECK_AND_ASSERT_MES(!t.pruned, false, "Cannot calculate the hash of a pruned transaction");
+
     // v1 transactions hash the entire blob
     if (t.version == 1)
     {
@@ -1091,8 +1160,7 @@ namespace cryptonote
     {
       if (!t.is_blob_size_valid())
       {
-        t.blob_size = blob.size();
-        t.set_blob_size_valid(true);
+        t.set_blob_size(blob.size());
       }
       *blob_size = t.blob_size;
     }
@@ -1112,8 +1180,7 @@ namespace cryptonote
       {
         if (!t.is_blob_size_valid())
         {
-          t.blob_size = get_object_blobsize(t);
-          t.set_blob_size_valid(true);
+          t.set_blob_size(get_object_blobsize(t));
         }
         *blob_size = t.blob_size;
       }
@@ -1124,12 +1191,10 @@ namespace cryptonote
     bool ret = calculate_transaction_hash(t, res, blob_size);
     if (!ret)
       return false;
-    t.hash = res;
-    t.set_hash_valid(true);
+    t.set_hash(res);
     if (blob_size)
     {
-      t.blob_size = *blob_size;
-      t.set_blob_size_valid(true);
+      t.set_blob_size(*blob_size);
     }
     return true;
   }
@@ -1206,8 +1271,7 @@ namespace cryptonote
     bool ret = calculate_block_hash(b, res);
     if (!ret)
       return false;
-    b.hash = res;
-    b.set_hash_valid(true);
+    b.set_hash(res);
     return true;
   }
   //---------------------------------------------------------------
@@ -1216,21 +1280,6 @@ namespace cryptonote
     crypto::hash p = null_hash;
     get_block_hash(b, p);
     return p;
-  }
-  //---------------------------------------------------------------
-  bool get_block_longhash(const block& b, crypto::hash& res, uint64_t height)
-  {
-    // block 202612 bug workaround
-    if (height == 202612)
-    {
-      static const std::string longhash_202612 = "84f64766475d51837ac9efbef1926486e58563c95a19fef4aec3254f03000000";
-      string_tools::hex_to_pod(longhash_202612, res);
-      return true;
-    }
-    blobdata bd = get_block_hashing_blob(b);
-    const int cn_variant = b.major_version >= 7 ? b.major_version - 6 : 0;
-    crypto::cn_slow_hash(bd.data(), bd.size(), res, cn_variant, height);
-    return true;
   }
   //---------------------------------------------------------------
   std::vector<uint64_t> relative_output_offsets_to_absolute(const std::vector<uint64_t>& off)
@@ -1253,13 +1302,6 @@ namespace cryptonote
     return res;
   }
   //---------------------------------------------------------------
-  crypto::hash get_block_longhash(const block& b, uint64_t height)
-  {
-    crypto::hash p = null_hash;
-    get_block_longhash(b, p, height);
-    return p;
-  }
-  //---------------------------------------------------------------
   bool parse_and_validate_block_from_blob(const blobdata& b_blob, block& b, crypto::hash *block_hash)
   {
     std::stringstream ss;
@@ -1273,8 +1315,7 @@ namespace cryptonote
     {
       calculate_block_hash(b, *block_hash, &b_blob);
       ++block_hashes_calculated_count;
-      b.hash = *block_hash;
-      b.set_hash_valid(true);
+      b.set_hash(*block_hash);
     }
     return true;
   }

--- a/cryptonote_basic/cryptonote_format_utils.h
+++ b/cryptonote_basic/cryptonote_format_utils.h
@@ -117,8 +117,6 @@ namespace cryptonote
   bool calculate_block_hash(const block& b, crypto::hash& res, const blobdata *blob = NULL);
   bool get_block_hash(const block& b, crypto::hash& res);
   crypto::hash get_block_hash(const block& b);
-  bool get_block_longhash(const block& b, crypto::hash& res, uint64_t height);
-  crypto::hash get_block_longhash(const block& b, uint64_t height);
   bool parse_and_validate_block_from_blob(const blobdata& b_blob, block& b, crypto::hash *block_hash);
   bool parse_and_validate_block_from_blob(const blobdata& b_blob, block& b);
   bool parse_and_validate_block_from_blob(const blobdata& b_blob, block& b, crypto::hash &block_hash);
@@ -129,6 +127,7 @@ namespace cryptonote
   bool parse_amount(uint64_t& amount, const std::string& str_amount);
   uint64_t get_transaction_weight(const transaction &tx);
   uint64_t get_transaction_weight(const transaction &tx, size_t blob_size);
+  uint64_t get_pruned_transaction_weight(const transaction &tx);
 
   bool check_money_overflow(const transaction& tx);
   bool check_outs_overflow(const transaction& tx);

--- a/cryptonote_config.h
+++ b/cryptonote_config.h
@@ -96,6 +96,7 @@
 #define BLOCKS_IDS_SYNCHRONIZING_DEFAULT_COUNT          10000  //by default, blocks ids count in synchronizing
 #define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_PRE_V4       100    //by default, blocks count in blocks downloading
 #define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT              20     //by default, blocks count in blocks downloading
+#define BLOCKS_SYNCHRONIZING_MAX_COUNT                  2048   //must be a power of 2, greater than 128, equal to SEEDHASH_EPOCH_BLOCKS
 
 #define CRYPTONOTE_MEMPOOL_TX_LIVETIME                    (86400*3) //seconds, three days
 #define CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME     604800 //seconds, one week
@@ -147,6 +148,7 @@
 #define CRYPTONOTE_BLOCKCHAINDATA_FILENAME      "data.mdb"
 #define CRYPTONOTE_BLOCKCHAINDATA_LOCK_FILENAME "lock.mdb"
 #define P2P_NET_DATA_FILENAME                   "p2pstate.bin"
+#define RPC_PAYMENTS_DATA_FILENAME              "rpcpayments.bin"
 #define MINER_CONFIG_FILE_NAME                  "miner_conf.json"
 
 #define THREAD_STACK_SIZE                       5 * 1024 * 1024
@@ -163,10 +165,12 @@
 #define HF_VERSION_MIN_V2_COINBASE_TX           12
 #define HF_VERSION_SAME_MIXIN                   12
 #define HF_VERSION_REJECT_SIGS_IN_COINBASE      12
+#define HF_VERSION_ENFORCE_MIN_AGE              12
+#define HF_VERSION_EFFECTIVE_SHORT_TERM_MEDIAN_IN_PENALTY 12
 
 #define PER_KB_FEE_QUANTIZATION_DECIMALS        8
 
-#define HASH_OF_HASHES_STEP                     256
+#define HASH_OF_HASHES_STEP                     512
 
 #define DEFAULT_TXPOOL_MAX_WEIGHT               648000000ull // 3 days at 300000, in bytes
 
@@ -176,6 +180,8 @@
 #define CRYPTONOTE_PRUNING_LOG_STRIPES          3 // the higher, the more space saved
 #define CRYPTONOTE_PRUNING_TIP_BLOCKS           5500 // the smaller, the more space saved
 //#define CRYPTONOTE_PRUNING_DEBUG_SPOOF_SEED
+
+#define RPC_CREDITS_PER_HASH_SCALE ((float)(1<<24))
 
 // New constants are intended to go here
 namespace config

--- a/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/cryptonote_core/cryptonote_tx_utils.cpp
@@ -642,15 +642,4 @@ namespace cryptonote
      std::vector<tx_destination_entry> destinations_copy = destinations;
      return construct_tx_and_get_tx_key(sender_account_keys, subaddresses, sources, destinations_copy, change_addr, extra, tx, unlock_time, tx_key, additional_tx_keys, false, { rct::RangeProofBorromean, 0}, NULL);
   }
-  //---------------------------------------------------------------
-  void get_altblock_longhash(const block& b, crypto::hash& res, const uint64_t main_height, const uint64_t height, const uint64_t seed_height, const crypto::hash& seed_hash)
-  {
-    blobdata bd = get_block_hashing_blob(b);
-    rx_slow_hash(main_height, seed_height, seed_hash.data, bd.data(), bd.size(), res.data, 0, 1);
-  }
-
-  void get_block_longhash_reorg(const uint64_t split_height)
-  {
-    rx_reorg(split_height);
-  }
 }

--- a/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/cryptonote_core/cryptonote_tx_utils.cpp
@@ -37,7 +37,6 @@ using namespace epee;
 #include "common/apply_permutation.h"
 #include "cryptonote_tx_utils.h"
 #include "cryptonote_config.h"
-// #include "cryptonote_basic/miner.h"
 #include "cryptonote_basic/tx_extra.h"
 #include "crypto/crypto.h"
 #include "crypto/hash.h"
@@ -611,23 +610,27 @@ namespace cryptonote
   {
     hw::device &hwdev = sender_account_keys.get_device();
     hwdev.open_tx(tx_key);
+    try {
+      // figure out if we need to make additional tx pubkeys
+      size_t num_stdaddresses = 0;
+      size_t num_subaddresses = 0;
+      account_public_address single_dest_subaddress;
+      classify_addresses(destinations, change_addr, num_stdaddresses, num_subaddresses, single_dest_subaddress);
+      bool need_additional_txkeys = num_subaddresses > 0 && (num_stdaddresses > 0 || num_subaddresses > 1);
+      if (need_additional_txkeys)
+      {
+        additional_tx_keys.clear();
+        for (const auto &d: destinations)
+          additional_tx_keys.push_back(keypair::generate(sender_account_keys.get_device()).sec);
+      }
 
-    // figure out if we need to make additional tx pubkeys
-    size_t num_stdaddresses = 0;
-    size_t num_subaddresses = 0;
-    account_public_address single_dest_subaddress;
-    classify_addresses(destinations, change_addr, num_stdaddresses, num_subaddresses, single_dest_subaddress);
-    bool need_additional_txkeys = num_subaddresses > 0 && (num_stdaddresses > 0 || num_subaddresses > 1);
-    if (need_additional_txkeys)
-    {
-      additional_tx_keys.clear();
-      for (const auto &d: destinations)
-        additional_tx_keys.push_back(keypair::generate(sender_account_keys.get_device()).sec);
+      bool r = construct_tx_with_tx_key(sender_account_keys, subaddresses, sources, destinations, change_addr, extra, tx, unlock_time, tx_key, additional_tx_keys, rct, rct_config, msout);
+      hwdev.close_tx();
+      return r;
+    } catch(...) {
+      hwdev.close_tx();
+      throw;
     }
-
-    bool r = construct_tx_with_tx_key(sender_account_keys, subaddresses, sources, destinations, change_addr, extra, tx, unlock_time, tx_key, additional_tx_keys, rct, rct_config, msout);
-    hwdev.close_tx();
-    return r;
   }
   //---------------------------------------------------------------
   bool construct_tx(const account_keys& sender_account_keys, std::vector<tx_source_entry>& sources, const std::vector<tx_destination_entry>& destinations, const boost::optional<cryptonote::account_public_address>& change_addr, const std::vector<uint8_t> &extra, transaction& tx, uint64_t unlock_time)
@@ -640,27 +643,14 @@ namespace cryptonote
      return construct_tx_and_get_tx_key(sender_account_keys, subaddresses, sources, destinations_copy, change_addr, extra, tx, unlock_time, tx_key, additional_tx_keys, false, { rct::RangeProofBorromean, 0}, NULL);
   }
   //---------------------------------------------------------------
-  // bool generate_genesis_block(
-  //     block& bl
-  //   , std::string const & genesis_tx
-  //   , uint32_t nonce
-  //   )
-  // {
-  //   //genesis block
-  //   bl = boost::value_initialized<block>();
+  void get_altblock_longhash(const block& b, crypto::hash& res, const uint64_t main_height, const uint64_t height, const uint64_t seed_height, const crypto::hash& seed_hash)
+  {
+    blobdata bd = get_block_hashing_blob(b);
+    rx_slow_hash(main_height, seed_height, seed_hash.data, bd.data(), bd.size(), res.data, 0, 1);
+  }
 
-  //   blobdata tx_bl;
-  //   bool r = string_tools::parse_hexstr_to_binbuff(genesis_tx, tx_bl);
-  //   CHECK_AND_ASSERT_MES(r, false, "failed to parse coinbase tx from hard coded blob");
-  //   r = parse_and_validate_tx_from_blob(tx_bl, bl.miner_tx);
-  //   CHECK_AND_ASSERT_MES(r, false, "failed to parse coinbase tx from hard coded blob");
-  //   bl.major_version = CURRENT_BLOCK_MAJOR_VERSION;
-  //   bl.minor_version = CURRENT_BLOCK_MINOR_VERSION;
-  //   bl.timestamp = 0;
-  //   bl.nonce = nonce;
-  //   miner::find_nonce_for_given_block(bl, 1, 0);
-  //   bl.invalidate_hashes();
-  //   return true;
-  // }
-  //---------------------------------------------------------------
+  void get_block_longhash_reorg(const uint64_t split_height)
+  {
+    rx_reorg(split_height);
+  }
 }

--- a/cryptonote_core/cryptonote_tx_utils.h
+++ b/cryptonote_core/cryptonote_tx_utils.h
@@ -132,6 +132,13 @@ namespace cryptonote
   //   , uint32_t nonce
   //   );
 
+  class Blockchain;
+  bool get_block_longhash(const Blockchain *pb, const block& b, crypto::hash& res, const uint64_t height, const int miners);
+  void get_altblock_longhash(const block& b, crypto::hash& res, const uint64_t main_height, const uint64_t height,
+    const uint64_t seed_height, const crypto::hash& seed_hash);
+  crypto::hash get_block_longhash(const Blockchain *pb, const block& b, const uint64_t height, const int miners);
+  void get_block_longhash_reorg(const uint64_t split_height);
+
 }
 
 BOOST_CLASS_VERSION(cryptonote::tx_source_entry, 1)

--- a/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -56,6 +56,7 @@ namespace cryptonote
     std::string ip;
     std::string port;
     uint16_t rpc_port;
+    uint32_t rpc_credits_per_hash;
 
     std::string peer_id;
 
@@ -94,6 +95,7 @@ namespace cryptonote
       KV_SERIALIZE(ip)
       KV_SERIALIZE(port)
       KV_SERIALIZE(rpc_port)
+      KV_SERIALIZE(rpc_credits_per_hash)
       KV_SERIALIZE(peer_id)
       KV_SERIALIZE(recv_count)
       KV_SERIALIZE(recv_idle_time)
@@ -116,14 +118,51 @@ namespace cryptonote
   /************************************************************************/
   /*                                                                      */
   /************************************************************************/
+  struct tx_blob_entry
+  {
+    blobdata blob;
+    crypto::hash prunable_hash;
+    BEGIN_KV_SERIALIZE_MAP()
+      KV_SERIALIZE(blob)
+      KV_SERIALIZE_VAL_POD_AS_BLOB(prunable_hash)
+    END_KV_SERIALIZE_MAP()
+
+    tx_blob_entry(const blobdata &bd = {}, const crypto::hash &h = crypto::null_hash): blob(bd), prunable_hash(h) {}
+  };
   struct block_complete_entry
   {
+    bool pruned;
     blobdata block;
-    std::vector<blobdata> txs;
+    uint64_t block_weight;
+    std::vector<tx_blob_entry> txs;
     BEGIN_KV_SERIALIZE_MAP()
+      KV_SERIALIZE_OPT(pruned, false)
       KV_SERIALIZE(block)
-      KV_SERIALIZE(txs)
+      KV_SERIALIZE_OPT(block_weight, (uint64_t)0)
+      if (this_ref.pruned)
+      {
+        KV_SERIALIZE(txs)
+      }
+      else
+      {
+        std::vector<blobdata> txs;
+        if (is_store)
+        {
+          txs.reserve(this_ref.txs.size());
+          for (const auto &e: this_ref.txs) txs.push_back(e.blob);
+        }
+        epee::serialization::selector<is_store>::serialize(txs, stg, hparent_section, "txs");
+        if (!is_store)
+        {
+          block_complete_entry &self = const_cast<block_complete_entry&>(this_ref);
+          self.txs.clear();
+          self.txs.reserve(txs.size());
+          for (auto &e: txs) self.txs.push_back({std::move(e), crypto::null_hash});
+        }
+      }
     END_KV_SERIALIZE_MAP()
+
+    block_complete_entry(): pruned(false), block_weight(0) {}
   };
 
 
@@ -176,8 +215,11 @@ namespace cryptonote
     struct request_t
     {
       std::vector<crypto::hash> blocks;
+      bool prune;
+
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_CONTAINER_POD_AS_BLOB(blocks)
+        KV_SERIALIZE_OPT(prune, false)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
@@ -229,9 +271,11 @@ namespace cryptonote
     struct request_t
     {
       std::list<crypto::hash> block_ids; /*IDs of the first 10 blocks are sequential, next goes with pow(2,n) offset, like 2, 4, 8, 16, 32, 64 and so on, and the last one is always genesis block */
+      bool prune;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_CONTAINER_POD_AS_BLOB(block_ids)
+        KV_SERIALIZE_OPT(prune, false)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
@@ -248,6 +292,7 @@ namespace cryptonote
       uint64_t cumulative_difficulty;
       uint64_t cumulative_difficulty_top64;
       std::vector<crypto::hash> m_block_ids;
+      std::vector<uint64_t> m_block_weights;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(start_height)
@@ -255,6 +300,7 @@ namespace cryptonote
         KV_SERIALIZE(cumulative_difficulty)
         KV_SERIALIZE(cumulative_difficulty_top64)
         KV_SERIALIZE_CONTAINER_POD_AS_BLOB(m_block_ids)
+        KV_SERIALIZE_CONTAINER_POD_AS_BLOB(m_block_weights)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;

--- a/epee/include/int-util.h
+++ b/epee/include/int-util.h
@@ -129,6 +129,26 @@ static inline uint32_t div128_32(uint64_t dividend_hi, uint64_t dividend_lo, uin
   return remainder;
 }
 
+// Long divisor with 2^64 base
+void div128_64(uint64_t dividend_hi, uint64_t dividend_lo, uint64_t divisor, uint64_t* quotient_hi, uint64_t *quotient_lo, uint64_t *remainder_hi, uint64_t *remainder_lo);
+
+static inline void add64clamp(uint64_t *value, uint64_t add)
+{
+  static const uint64_t maxval = (uint64_t)-1;
+  if (*value > maxval - add)
+    *value = maxval;
+  else
+    *value += add;
+}
+
+static inline void sub64clamp(uint64_t *value, uint64_t sub)
+{
+  if (*value < sub)
+    *value = 0;
+  else
+    *value -= sub;
+}
+
 #define IDENT16(x) ((uint16_t) (x))
 #define IDENT32(x) ((uint32_t) (x))
 #define IDENT64(x) ((uint64_t) (x))

--- a/epee/include/misc_log_ex.h
+++ b/epee/include/misc_log_ex.h
@@ -31,11 +31,8 @@
 #include "logger.h"
 #include <sstream>
 
-#undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "default"
 
-
-#if 1
 #define MCFATAL(cat,x) (LOGGER_ERROR() << x); std::abort()
 #define MCERROR(cat,x) LOGGER_ERROR() << x
 #define MCWARNING(cat,x) LOGGER_WARNING() << x
@@ -44,23 +41,6 @@
 #define MCTRACE(cat,x) LOGGER_DEBUG() << x
 #define MCLOG(level,cat,x) LOGGER_LOG(level) << x
 #define MCLOG_FILE(level,cat,x) MCLOG(level,cat,x)
-#else
-#define MCLOG_TYPE(level, cat, type, x) do { \
-    if (ELPP->vRegistry()->allowed(level, cat)) { \
-      el::base::Writer(level, __FILE__, __LINE__, ELPP_FUNC, type).construct(cat) << x; \
-    } \
-  } while (0)
-
-#define MCLOG(level, cat, x) MCLOG_TYPE(level, cat, el::base::DispatchAction::NormalLog, x)
-#define MCLOG_FILE(level, cat, x) MCLOG_TYPE(level, cat, el::base::DispatchAction::FileOnlyLog, x)
-
-#define MCFATAL(cat,x) MCLOG(el::Level::Fatal,cat, x)
-#define MCERROR(cat,x) MCLOG(el::Level::Error,cat, x)
-#define MCWARNING(cat,x) MCLOG(el::Level::Warning,cat, x)
-#define MCINFO(cat,x) MCLOG(el::Level::Info,cat, x)
-#define MCDEBUG(cat,x) MCLOG(el::Level::Debug,cat, x)
-#define MCTRACE(cat,x) MCLOG(el::Level::Trace,cat, x)
-#endif
 
 #define MCLOG_COLOR(level,cat,color,x) MCLOG(level,cat,"\033[1;" color "m" << x << "\033[0m")
 #define MCLOG_RED(level,cat,x) MCLOG_COLOR(level,cat,"31",x)
@@ -92,16 +72,6 @@
 #define MGINFO_BLUE(x) MCLOG_BLUE(logger::kInfo, "global",x)
 #define MGINFO_MAGENTA(x) MCLOG_MAGENTA(logger::kInfo, "global",x)
 #define MGINFO_CYAN(x) MCLOG_CYAN(logger::kInfo, "global",x)
-
-#define IFLOG(level, cat, type, init, x) \
-  do { \
-    if (ELPP->vRegistry()->allowed(level, cat)) { \
-      init; \
-      el::base::Writer(level, __FILE__, __LINE__, ELPP_FUNC, type).construct(cat) << x; \
-    } \
-  } while(0)
-#define MIDEBUG(init, x) IFLOG(el::Level::Debug, MONERO_DEFAULT_LOG_CATEGORY, el::base::DispatchAction::NormalLog, init, x)
-
 
 #define LOG_ERROR(x) MERROR(x)
 #define LOG_PRINT_L0(x) MWARNING(x)

--- a/epee/include/serialization/keyvalue_serialization.h
+++ b/epee/include/serialization/keyvalue_serialization.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <type_traits>
 #include <boost/utility/value_init.hpp>
 #include <boost/foreach.hpp>
 #include "misc_log_ex.h"
@@ -45,18 +46,20 @@ public: \
   template<class t_storage> \
   bool store( t_storage& st, typename t_storage::hsection hparent_section = nullptr) const\
   {\
-    return serialize_map<true>(*this, st, hparent_section);\
+    using type = typename std::remove_const<typename std::remove_reference<decltype(*this)>::type>::type; \
+    auto &self = const_cast<type&>(*this); \
+    return self.template serialize_map<true>(st, hparent_section); \
   }\
   template<class t_storage> \
   bool _load( t_storage& stg, typename t_storage::hsection hparent_section = nullptr)\
   {\
-    return serialize_map<false>(*this, stg, hparent_section);\
+    return serialize_map<false>(stg, hparent_section);\
   }\
   template<class t_storage> \
   bool load( t_storage& stg, typename t_storage::hsection hparent_section = nullptr)\
   {\
     try{\
-    return serialize_map<false>(*this, stg, hparent_section);\
+    return serialize_map<false>(stg, hparent_section);\
     }\
     catch(const std::exception& err) \
     { \
@@ -65,12 +68,21 @@ public: \
       return false; \
     }\
   }\
-  template<bool is_store, class this_type, class t_storage> \
-  static bool serialize_map(this_type& this_ref,  t_storage& stg, typename t_storage::hsection hparent_section) \
-  { 
+  /*template<typename T> T& this_type_resolver() { return *this; }*/ \
+  /*using this_type = std::result_of<decltype(this_type_resolver)>::type;*/ \
+  template<bool is_store, class t_storage> \
+  bool serialize_map(t_storage& stg, typename t_storage::hsection hparent_section) \
+  { \
+    decltype(*this) &this_ref = *this;
 
 #define KV_SERIALIZE_N(varialble, val_name) \
   epee::serialization::selector<is_store>::serialize(this_ref.varialble, stg, hparent_section, val_name);
+
+#define KV_SERIALIZE_PARENT(type) \
+  do { \
+    if (!((type*)this)->serialize_map<is_store, t_storage>(stg, hparent_section)) \
+      return false; \
+  } while(0);
 
   template<typename T> inline void serialize_default(const T &t, T v) { }
   template<typename T> inline void serialize_default(T &t, T v) { t = v; }

--- a/epee/src/connection_basic.cpp
+++ b/epee/src/connection_basic.cpp
@@ -136,6 +136,7 @@ connection_basic::connection_basic(boost::asio::ip::tcp::socket&& sock, std::sha
 	socket_(GET_IO_SERVICE(sock), get_context(m_state.get())),
 	m_want_close_connection(false),
 	m_was_shutdown(false),
+	m_is_multithreaded(false),
 	m_ssl_support(ssl_support)
 {
 	// add nullptr checks if removed
@@ -160,6 +161,7 @@ connection_basic::connection_basic(boost::asio::io_service &io_service, std::sha
 	socket_(io_service, get_context(m_state.get())),
 	m_want_close_connection(false),
 	m_was_shutdown(false),
+	m_is_multithreaded(false),
 	m_ssl_support(ssl_support)
 {
 	// add nullptr checks if removed

--- a/ringct/rctTypes.h
+++ b/ringct/rctTypes.h
@@ -321,6 +321,7 @@ namespace rct {
         std::vector<mgSig> MGs; // simple rct has N, full has 1
         keyV pseudoOuts; //C - for simple rct
 
+        // when changing this function, update cryptonote::get_pruned_transaction_weight
         template<bool W, template <bool> class Archive>
         bool serialize_rctsig_prunable(Archive<W> &ar, uint8_t type, size_t inputs, size_t outputs, size_t mixin)
         {

--- a/rpc/core_rpc_server_commands_defs.h
+++ b/rpc/core_rpc_server_commands_defs.h
@@ -78,6 +78,7 @@ namespace cryptonote
 #define CORE_RPC_STATUS_OK   "OK"
 #define CORE_RPC_STATUS_BUSY   "BUSY"
 #define CORE_RPC_STATUS_NOT_MINING "NOT MINING"
+#define CORE_RPC_STATUS_PAYMENT_REQUIRED "PAYMENT REQUIRED"
 
 // When making *any* change here, bump minor
 // If the change is incompatible, then bump major and set minor to 0
@@ -86,31 +87,72 @@ namespace cryptonote
 // whether they can talk to a given daemon without having to know in
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
-#define CORE_RPC_VERSION_MAJOR 2
-#define CORE_RPC_VERSION_MINOR 10
+#define CORE_RPC_VERSION_MAJOR 3
+#define CORE_RPC_VERSION_MINOR 0
 #define MAKE_CORE_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define CORE_RPC_VERSION MAKE_CORE_RPC_VERSION(CORE_RPC_VERSION_MAJOR, CORE_RPC_VERSION_MINOR)
 
+  struct rpc_request_base
+  {
+    BEGIN_KV_SERIALIZE_MAP()
+    END_KV_SERIALIZE_MAP()
+  };
+
+  struct rpc_response_base
+  {
+    std::string status;
+    bool untrusted;
+
+    rpc_response_base(): untrusted(false) {}
+
+    BEGIN_KV_SERIALIZE_MAP()
+      KV_SERIALIZE(status)
+      KV_SERIALIZE(untrusted)
+    END_KV_SERIALIZE_MAP()
+  };
+
+  struct rpc_access_request_base: public rpc_request_base
+  {
+    std::string client;
+
+    BEGIN_KV_SERIALIZE_MAP()
+      KV_SERIALIZE_PARENT(rpc_request_base)
+      KV_SERIALIZE(client)
+    END_KV_SERIALIZE_MAP()
+  };
+
+  struct rpc_access_response_base: public rpc_response_base
+  {
+    uint64_t credits;
+    std::string top_hash;
+
+    rpc_access_response_base(): credits(0) {}
+
+    BEGIN_KV_SERIALIZE_MAP()
+      KV_SERIALIZE_PARENT(rpc_response_base)
+      KV_SERIALIZE(credits)
+      KV_SERIALIZE(top_hash)
+    END_KV_SERIALIZE_MAP()
+  };
+
   struct COMMAND_RPC_GET_HEIGHT
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
       uint64_t 	 height;
-      std::string status;
-      bool untrusted;
       std::string hash;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(height)
-        KV_SERIALIZE(status)
-        KV_SERIALIZE(untrusted)
         KV_SERIALIZE(hash)
       END_KV_SERIALIZE_MAP()
     };
@@ -120,13 +162,14 @@ namespace cryptonote
   struct COMMAND_RPC_GET_BLOCKS_FAST
   {
 
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       std::list<crypto::hash> block_ids; //*first 10 blocks id goes sequential, next goes in pow(2,n) offset, like 2, 4, 8, 16, 32, 64 and so on, and the last one is always genesis block */
       uint64_t    start_height;
       bool        prune;
       bool        no_miner_tx;
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
         KV_SERIALIZE_CONTAINER_POD_AS_BLOB(block_ids)
         KV_SERIALIZE(start_height)
         KV_SERIALIZE(prune)
@@ -153,22 +196,19 @@ namespace cryptonote
       END_KV_SERIALIZE_MAP()
     };
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
       std::vector<block_complete_entry> blocks;
       uint64_t    start_height;
       uint64_t    current_height;
-      std::string status;
       std::vector<block_output_indices> output_indices;
-      bool untrusted;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(blocks)
         KV_SERIALIZE(start_height)
         KV_SERIALIZE(current_height)
-        KV_SERIALIZE(status)
         KV_SERIALIZE(output_indices)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -176,25 +216,23 @@ namespace cryptonote
 
   struct COMMAND_RPC_GET_BLOCKS_BY_HEIGHT
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       std::vector<uint64_t> heights;
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
         KV_SERIALIZE(heights)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
       std::vector<block_complete_entry> blocks;
-      std::string status;
-      bool untrusted;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(blocks)
-        KV_SERIALIZE(status)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -202,23 +240,21 @@ namespace cryptonote
 
     struct COMMAND_RPC_GET_ALT_BLOCKS_HASHES
     {
-        struct request_t
+        struct request_t: public rpc_access_request_base
         {
             BEGIN_KV_SERIALIZE_MAP()
+                KV_SERIALIZE_PARENT(rpc_access_request_base)
             END_KV_SERIALIZE_MAP()
         };
         typedef epee::misc_utils::struct_init<request_t> request;
 
-        struct response_t
+        struct response_t: public rpc_access_response_base
         {
             std::vector<std::string> blks_hashes;
-            std::string status;
-            bool untrusted;
 
             BEGIN_KV_SERIALIZE_MAP()
+                KV_SERIALIZE_PARENT(rpc_access_response_base)
                 KV_SERIALIZE(blks_hashes)
-                KV_SERIALIZE(status)
-                KV_SERIALIZE(untrusted)
             END_KV_SERIALIZE_MAP()
         };
         typedef epee::misc_utils::struct_init<response_t> response;
@@ -226,31 +262,29 @@ namespace cryptonote
   struct COMMAND_RPC_GET_HASHES_FAST
   {
 
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       std::list<crypto::hash> block_ids; //*first 10 blocks id goes sequential, next goes in pow(2,n) offset, like 2, 4, 8, 16, 32, 64 and so on, and the last one is always genesis block */
       uint64_t    start_height;
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
         KV_SERIALIZE_CONTAINER_POD_AS_BLOB(block_ids)
         KV_SERIALIZE(start_height)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
       std::vector<crypto::hash> m_block_ids;
       uint64_t    start_height;
       uint64_t    current_height;
-      std::string status;
-      bool untrusted;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE_CONTAINER_POD_AS_BLOB(m_block_ids)
         KV_SERIALIZE(start_height)
         KV_SERIALIZE(current_height)
-        KV_SERIALIZE(status)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -288,7 +322,7 @@ namespace cryptonote
   //-----------------------------------------------
   struct COMMAND_RPC_GET_TRANSACTIONS
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       std::vector<std::string> txs_hashes;
       bool decode_as_json;
@@ -296,6 +330,7 @@ namespace cryptonote
       bool split;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
         KV_SERIALIZE(txs_hashes)
         KV_SERIALIZE(decode_as_json)
         KV_SERIALIZE_OPT(prune, false)
@@ -341,7 +376,7 @@ namespace cryptonote
       END_KV_SERIALIZE_MAP()
     };
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
       // older compatibility stuff
       std::vector<std::string> txs_as_hex;  //transactions blobs as hex (old compat)
@@ -352,16 +387,13 @@ namespace cryptonote
 
       // new style
       std::vector<entry> txs;
-      std::string status;
-      bool untrusted;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(txs_as_hex)
         KV_SERIALIZE(txs_as_json)
         KV_SERIALIZE(txs)
         KV_SERIALIZE(missed_tx)
-        KV_SERIALIZE(status)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -376,27 +408,25 @@ namespace cryptonote
       SPENT_IN_POOL = 2,
     };
 
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       std::vector<std::string> key_images;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
         KV_SERIALIZE(key_images)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
       std::vector<int> spent_status;
-      std::string status;
-      bool untrusted;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(spent_status)
-        KV_SERIALIZE(status)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -405,25 +435,24 @@ namespace cryptonote
   //-----------------------------------------------
   struct COMMAND_RPC_GET_TX_GLOBAL_OUTPUTS_INDEXES
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       crypto::hash txid;
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
         KV_SERIALIZE_VAL_POD_AS_BLOB(txid)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
       std::vector<uint64_t> o_indexes;
-      std::string status;
-      bool untrusted;
+
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(o_indexes)
-        KV_SERIALIZE(status)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -442,12 +471,13 @@ namespace cryptonote
 
   struct COMMAND_RPC_GET_OUTPUTS_BIN
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       std::vector<get_outputs_out> outputs;
       bool get_txid;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
         KV_SERIALIZE(outputs)
         KV_SERIALIZE_OPT(get_txid, true)
       END_KV_SERIALIZE_MAP()
@@ -471,16 +501,13 @@ namespace cryptonote
       END_KV_SERIALIZE_MAP()
     };
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
       std::vector<outkey> outs;
-      std::string status;
-      bool untrusted;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(outs)
-        KV_SERIALIZE(status)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -488,12 +515,13 @@ namespace cryptonote
   //-----------------------------------------------
   struct COMMAND_RPC_GET_OUTPUTS
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       std::vector<get_outputs_out> outputs;
       bool get_txid;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
         KV_SERIALIZE(outputs)
         KV_SERIALIZE(get_txid)
       END_KV_SERIALIZE_MAP()
@@ -517,16 +545,13 @@ namespace cryptonote
       END_KV_SERIALIZE_MAP()
     };
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
       std::vector<outkey> outs;
-      std::string status;
-      bool untrusted;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(outs)
-        KV_SERIALIZE(status)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -534,13 +559,14 @@ namespace cryptonote
   //-----------------------------------------------
   struct COMMAND_RPC_SEND_RAW_TX
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       std::string tx_as_hex;
       bool do_not_relay;
       bool do_sanity_checks;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base);
         KV_SERIALIZE(tx_as_hex)
         KV_SERIALIZE_OPT(do_not_relay, false)
         KV_SERIALIZE_OPT(do_sanity_checks, true)
@@ -549,9 +575,8 @@ namespace cryptonote
     typedef epee::misc_utils::struct_init<request_t> request;
 
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
-      std::string status;
       std::string reason;
       bool not_relayed;
       bool low_mixin;
@@ -564,10 +589,9 @@ namespace cryptonote
       bool not_rct;
       bool too_few_outputs;
       bool sanity_check_failed;
-      bool untrusted;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(reason)
         KV_SERIALIZE(not_relayed)
         KV_SERIALIZE(low_mixin)
@@ -580,7 +604,6 @@ namespace cryptonote
         KV_SERIALIZE(not_rct)
         KV_SERIALIZE(too_few_outputs)
         KV_SERIALIZE(sanity_check_failed)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -588,7 +611,7 @@ namespace cryptonote
   //-----------------------------------------------
   struct COMMAND_RPC_START_MINING
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       std::string miner_address;
       uint64_t    threads_count;
@@ -596,6 +619,7 @@ namespace cryptonote
       bool        ignore_battery;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
         KV_SERIALIZE(miner_address)
         KV_SERIALIZE(threads_count)
         KV_SERIALIZE(do_background_mining)        
@@ -604,12 +628,10 @@ namespace cryptonote
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
-
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -617,17 +639,16 @@ namespace cryptonote
   //-----------------------------------------------
   struct COMMAND_RPC_GET_INFO
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
-
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base);
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
-      std::string status;
       uint64_t height;
       uint64_t target_height;
       uint64_t difficulty;
@@ -657,7 +678,6 @@ namespace cryptonote
       uint64_t start_time;
       uint64_t free_space;
       bool offline;
-      bool untrusted;
       std::string bootstrap_daemon_address;
       uint64_t height_without_bootstrap;
       bool was_bootstrap_ever_used;
@@ -666,7 +686,7 @@ namespace cryptonote
       std::string version;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(height)
         KV_SERIALIZE(target_height)
         KV_SERIALIZE(difficulty)
@@ -696,7 +716,6 @@ namespace cryptonote
         KV_SERIALIZE(start_time)
         KV_SERIALIZE(free_space)
         KV_SERIALIZE(offline)
-        KV_SERIALIZE(untrusted)
         KV_SERIALIZE(bootstrap_daemon_address)
         KV_SERIALIZE(height_without_bootstrap)
         KV_SERIALIZE(was_bootstrap_ever_used)
@@ -712,18 +731,17 @@ namespace cryptonote
   //-----------------------------------------------
   struct COMMAND_RPC_GET_NET_STATS
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
-
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
       uint64_t start_time;
       uint64_t total_packets_in;
       uint64_t total_bytes_in;
@@ -731,7 +749,7 @@ namespace cryptonote
       uint64_t total_bytes_out;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(start_time)
         KV_SERIALIZE(total_packets_in)
         KV_SERIALIZE(total_bytes_in)
@@ -745,21 +763,19 @@ namespace cryptonote
   //-----------------------------------------------
   struct COMMAND_RPC_STOP_MINING
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
-
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
-
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -768,18 +784,17 @@ namespace cryptonote
   //-----------------------------------------------
   struct COMMAND_RPC_MINING_STATUS
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
-
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
       bool active;
       uint64_t speed;
       uint32_t threads_count;
@@ -797,7 +812,7 @@ namespace cryptonote
       uint64_t difficulty_top64;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(active)
         KV_SERIALIZE(speed)
         KV_SERIALIZE(threads_count)
@@ -821,21 +836,19 @@ namespace cryptonote
   //-----------------------------------------------
   struct COMMAND_RPC_SAVE_BC
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
-
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
-
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -846,14 +859,13 @@ namespace cryptonote
   {
     typedef std::list<std::string> request;
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
       uint64_t count;
-      std::string status;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(count)
-        KV_SERIALIZE(status)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -869,7 +881,7 @@ namespace cryptonote
 
   struct COMMAND_RPC_GETBLOCKTEMPLATE
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       uint64_t reserve_size;       //max 255 bytes
       std::string wallet_address;
@@ -877,6 +889,7 @@ namespace cryptonote
       std::string extra_nonce;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
         KV_SERIALIZE(reserve_size)
         KV_SERIALIZE(wallet_address)
         KV_SERIALIZE(prev_block)
@@ -885,7 +898,7 @@ namespace cryptonote
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
       uint64_t difficulty;
       std::string wide_difficulty;
@@ -894,12 +907,14 @@ namespace cryptonote
       uint64_t reserved_offset;
       uint64_t expected_reward;
       std::string prev_hash;
+      uint64_t seed_height;
+      std::string seed_hash;
+      std::string next_seed_hash;
       blobdata blocktemplate_blob;
       blobdata blockhashing_blob;
-      std::string status;
-      bool untrusted;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(difficulty)
         KV_SERIALIZE(wide_difficulty)
         KV_SERIALIZE(difficulty_top64)
@@ -907,10 +922,11 @@ namespace cryptonote
         KV_SERIALIZE(reserved_offset)
         KV_SERIALIZE(expected_reward)
         KV_SERIALIZE(prev_hash)
+        KV_SERIALIZE(seed_height)
         KV_SERIALIZE(blocktemplate_blob)
         KV_SERIALIZE(blockhashing_blob)
-        KV_SERIALIZE(status)
-        KV_SERIALIZE(untrusted)
+        KV_SERIALIZE(seed_hash)
+        KV_SERIALIZE(next_seed_hash)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -920,12 +936,10 @@ namespace cryptonote
   {
     typedef std::vector<std::string> request;
     
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
-
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -933,7 +947,7 @@ namespace cryptonote
 
   struct COMMAND_RPC_GENERATEBLOCKS
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       uint64_t amount_of_blocks;
       std::string wallet_address;
@@ -941,6 +955,7 @@ namespace cryptonote
       uint32_t starting_nonce;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
         KV_SERIALIZE(amount_of_blocks)
         KV_SERIALIZE(wallet_address)
         KV_SERIALIZE(prev_block)
@@ -949,16 +964,15 @@ namespace cryptonote
     };
     typedef epee::misc_utils::struct_init<request_t> request;
     
-    struct response_t
+    struct response_t: public rpc_response_base
     {
       uint64_t height;
       std::vector<std::string> blocks;
-      std::string status;
       
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(height)
         KV_SERIALIZE(blocks)
-        KV_SERIALIZE(status)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1017,26 +1031,24 @@ namespace cryptonote
 
   struct COMMAND_RPC_GET_LAST_BLOCK_HEADER
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       bool fill_pow_hash;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
         KV_SERIALIZE_OPT(fill_pow_hash, false);
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
-      std::string status;
       block_header_response block_header;
-      bool untrusted;
       
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(block_header)
-        KV_SERIALIZE(status)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1045,13 +1057,14 @@ namespace cryptonote
   
   struct COMMAND_RPC_GET_BLOCK_HEADER_BY_HASH
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       std::string hash;
       std::vector<std::string> hashes;
       bool fill_pow_hash;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
         KV_SERIALIZE(hash)
         KV_SERIALIZE(hashes)
         KV_SERIALIZE_OPT(fill_pow_hash, false);
@@ -1059,18 +1072,15 @@ namespace cryptonote
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
-      std::string status;
       block_header_response block_header;
       std::vector<block_header_response> block_headers;
-      bool untrusted;
       
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(block_header)
         KV_SERIALIZE(block_headers)
-        KV_SERIALIZE(status)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1078,28 +1088,26 @@ namespace cryptonote
 
   struct COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       uint64_t height;
       bool fill_pow_hash;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
         KV_SERIALIZE(height)
         KV_SERIALIZE_OPT(fill_pow_hash, false);
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
-      std::string status;
       block_header_response block_header;
-      bool untrusted;
       
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(block_header)
-        KV_SERIALIZE(status)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1107,13 +1115,14 @@ namespace cryptonote
 
   struct COMMAND_RPC_GET_BLOCK
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       std::string hash;
       uint64_t height;
       bool fill_pow_hash;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
         KV_SERIALIZE(hash)
         KV_SERIALIZE(height)
         KV_SERIALIZE_OPT(fill_pow_hash, false);
@@ -1121,24 +1130,21 @@ namespace cryptonote
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
-      std::string status;
       block_header_response block_header;
       std::string miner_tx_hash;
       std::vector<std::string> tx_hashes;
       std::string blob;
       std::string json;
-      bool untrusted;
       
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(block_header)
         KV_SERIALIZE(miner_tx_hash)
         KV_SERIALIZE(tx_hashes)
-        KV_SERIALIZE(status)
         KV_SERIALIZE(blob)
         KV_SERIALIZE(json)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1150,19 +1156,20 @@ namespace cryptonote
     uint32_t ip;
     uint16_t port;
     uint16_t rpc_port;
+    uint32_t rpc_credits_per_hash;
     uint64_t last_seen;
     uint32_t pruning_seed;
 
     peer() = default;
 
-    peer(uint64_t id, const std::string &host, uint64_t last_seen, uint32_t pruning_seed, uint16_t rpc_port)
-      : id(id), host(host), ip(0), port(0), rpc_port(rpc_port), last_seen(last_seen), pruning_seed(pruning_seed)
+    peer(uint64_t id, const std::string &host, uint64_t last_seen, uint32_t pruning_seed, uint16_t rpc_port, uint32_t rpc_credits_per_hash)
+      : id(id), host(host), ip(0), port(0), rpc_port(rpc_port), rpc_credits_per_hash(rpc_credits_per_hash), last_seen(last_seen), pruning_seed(pruning_seed)
     {}
-    peer(uint64_t id, const std::string &host, uint16_t port, uint64_t last_seen, uint32_t pruning_seed, uint16_t rpc_port)
-      : id(id), host(host), ip(0), port(port), rpc_port(rpc_port), last_seen(last_seen), pruning_seed(pruning_seed)
+    peer(uint64_t id, const std::string &host, uint16_t port, uint64_t last_seen, uint32_t pruning_seed, uint16_t rpc_port, uint32_t rpc_credits_per_hash)
+      : id(id), host(host), ip(0), port(port), rpc_port(rpc_port), rpc_credits_per_hash(rpc_credits_per_hash), last_seen(last_seen), pruning_seed(pruning_seed)
     {}
-    peer(uint64_t id, uint32_t ip, uint16_t port, uint64_t last_seen, uint32_t pruning_seed, uint16_t rpc_port)
-      : id(id), host(epee::string_tools::get_ip_string_from_int32(ip)), ip(ip), port(port), rpc_port(rpc_port), last_seen(last_seen), pruning_seed(pruning_seed)
+    peer(uint64_t id, uint32_t ip, uint16_t port, uint64_t last_seen, uint32_t pruning_seed, uint16_t rpc_port, uint32_t rpc_credits_per_hash)
+      : id(id), host(epee::string_tools::get_ip_string_from_int32(ip)), ip(ip), port(port), rpc_port(rpc_port), rpc_credits_per_hash(rpc_credits_per_hash), last_seen(last_seen), pruning_seed(pruning_seed)
     {}
 
     BEGIN_KV_SERIALIZE_MAP()
@@ -1171,6 +1178,7 @@ namespace cryptonote
       KV_SERIALIZE(ip)
       KV_SERIALIZE(port)
       KV_SERIALIZE_OPT(rpc_port, (uint16_t)0)
+      KV_SERIALIZE_OPT(rpc_credits_per_hash, (uint32_t)0)
       KV_SERIALIZE(last_seen)
       KV_SERIALIZE_OPT(pruning_seed, (uint32_t)0)
     END_KV_SERIALIZE_MAP()
@@ -1178,24 +1186,24 @@ namespace cryptonote
 
   struct COMMAND_RPC_GET_PEER_LIST
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       bool public_only;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
         KV_SERIALIZE_OPT(public_only, true)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
       std::vector<peer> white_list;
       std::vector<peer> gray_list;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(white_list)
         KV_SERIALIZE(gray_list)
       END_KV_SERIALIZE_MAP()
@@ -1208,42 +1216,44 @@ namespace cryptonote
     std::string host;
     uint64_t last_seen;
     uint16_t rpc_port;
+    uint32_t rpc_credits_per_hash;
 
-    public_node() = delete;
+    public_node(): last_seen(0), rpc_port(0), rpc_credits_per_hash(0) {}
 
     public_node(const peer &peer)
-      : host(peer.host), last_seen(peer.last_seen), rpc_port(peer.rpc_port)
+      : host(peer.host), last_seen(peer.last_seen), rpc_port(peer.rpc_port), rpc_credits_per_hash(peer.rpc_credits_per_hash)
     {}
 
     BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE(host)
       KV_SERIALIZE(last_seen)
       KV_SERIALIZE(rpc_port)
+      KV_SERIALIZE(rpc_credits_per_hash)
     END_KV_SERIALIZE_MAP()
   };
 
   struct COMMAND_RPC_GET_PUBLIC_NODES
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       bool gray;
       bool white;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
         KV_SERIALIZE_OPT(gray, false)
         KV_SERIALIZE_OPT(white, true)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
       std::vector<public_node> gray;
       std::vector<public_node> white;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(gray)
         KV_SERIALIZE(white)
       END_KV_SERIALIZE_MAP()
@@ -1253,21 +1263,21 @@ namespace cryptonote
 
   struct COMMAND_RPC_SET_LOG_HASH_RATE
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       bool visible;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
         KV_SERIALIZE(visible)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1275,21 +1285,21 @@ namespace cryptonote
 
   struct COMMAND_RPC_SET_LOG_LEVEL
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       int8_t level;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
         KV_SERIALIZE(level)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1297,23 +1307,23 @@ namespace cryptonote
 
   struct COMMAND_RPC_SET_LOG_CATEGORIES
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       std::string categories;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
         KV_SERIALIZE(categories)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
       std::string categories;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(categories)
       END_KV_SERIALIZE_MAP()
     };
@@ -1372,25 +1382,23 @@ namespace cryptonote
 
   struct COMMAND_RPC_GET_TRANSACTION_POOL
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
-      std::string status;
       std::vector<tx_info> transactions;
       std::vector<spent_key_image_info> spent_key_images;
-      bool untrusted;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(transactions)
         KV_SERIALIZE(spent_key_images)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1398,23 +1406,21 @@ namespace cryptonote
 
   struct COMMAND_RPC_GET_TRANSACTION_POOL_HASHES_BIN
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
-      std::string status;
       std::vector<crypto::hash> tx_hashes;
-      bool untrusted;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE_CONTAINER_POD_AS_BLOB(tx_hashes)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1422,23 +1428,21 @@ namespace cryptonote
 
   struct COMMAND_RPC_GET_TRANSACTION_POOL_HASHES
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
-      std::string status;
       std::vector<std::string> tx_hashes;
-      bool untrusted;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(tx_hashes)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1453,23 +1457,21 @@ namespace cryptonote
 
   struct COMMAND_RPC_GET_TRANSACTION_POOL_BACKLOG
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
-      std::string status;
       std::vector<tx_backlog_entry> backlog;
-      bool untrusted;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE_CONTAINER_POD_AS_BLOB(backlog)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1516,30 +1518,28 @@ namespace cryptonote
       KV_SERIALIZE(num_10m)
       KV_SERIALIZE(num_not_relayed)
       KV_SERIALIZE(histo_98pc)
-      KV_SERIALIZE_CONTAINER_POD_AS_BLOB(histo)
+      KV_SERIALIZE(histo)
       KV_SERIALIZE(num_double_spends)
     END_KV_SERIALIZE_MAP()
   };
 
   struct COMMAND_RPC_GET_TRANSACTION_POOL_STATS
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
-      std::string status;
       txpool_stats pool_stats;
-      bool untrusted;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(pool_stats)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1547,20 +1547,20 @@ namespace cryptonote
 
   struct COMMAND_RPC_GET_CONNECTIONS
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
       std::list<connection_info> connections;
       
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(connections)
       END_KV_SERIALIZE_MAP()
     };
@@ -1569,13 +1569,14 @@ namespace cryptonote
 
   struct COMMAND_RPC_GET_BLOCK_HEADERS_RANGE
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       uint64_t start_height;
       uint64_t end_height;
       bool fill_pow_hash;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
         KV_SERIALIZE(start_height)
         KV_SERIALIZE(end_height)
         KV_SERIALIZE_OPT(fill_pow_hash, false);
@@ -1583,16 +1584,13 @@ namespace cryptonote
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
-      std::string status;
       std::vector<block_header_response> headers;
-      bool untrusted;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(headers)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1627,19 +1625,18 @@ namespace cryptonote
 
   struct COMMAND_RPC_STOP_DAEMON
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
-
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1647,19 +1644,18 @@ namespace cryptonote
   
   struct COMMAND_RPC_FAST_EXIT
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
     
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-	  std::string status;
-	  
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1667,25 +1663,23 @@ namespace cryptonote
   
   struct COMMAND_RPC_GET_LIMIT
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
     
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
       uint64_t limit_up;
       uint64_t limit_down;
-      bool untrusted;
       
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(limit_up)
         KV_SERIALIZE(limit_down)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1693,26 +1687,26 @@ namespace cryptonote
   
   struct COMMAND_RPC_SET_LIMIT
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       int64_t limit_down;  // all limits (for get and set) are kB/s
       int64_t limit_up;
       
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
         KV_SERIALIZE(limit_down)
         KV_SERIALIZE(limit_up)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
     
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
       int64_t limit_up;
       int64_t limit_down;
       
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(limit_up)
         KV_SERIALIZE(limit_down)
       END_KV_SERIALIZE_MAP()
@@ -1722,25 +1716,26 @@ namespace cryptonote
   
   struct COMMAND_RPC_OUT_PEERS
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       bool set;
       uint32_t out_peers;
+
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
         KV_SERIALIZE_OPT(set, true)
         KV_SERIALIZE(out_peers)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
     
-    struct response_t
+    struct response_t: public rpc_response_base
     {
       uint32_t out_peers;
-      std::string status;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(out_peers)
-        KV_SERIALIZE(status)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1748,25 +1743,25 @@ namespace cryptonote
 
   struct COMMAND_RPC_IN_PEERS
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       bool set;
       uint32_t in_peers;
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
         KV_SERIALIZE_OPT(set, true)
         KV_SERIALIZE(in_peers)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
       uint32_t in_peers;
-      std::string status;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(in_peers)
-        KV_SERIALIZE(status)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1774,17 +1769,18 @@ namespace cryptonote
     
   struct COMMAND_RPC_HARD_FORK_INFO
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       uint8_t version;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
         KV_SERIALIZE(version)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
       uint8_t version;
       bool enabled;
@@ -1794,10 +1790,9 @@ namespace cryptonote
       uint8_t voting;
       uint32_t state;
       uint64_t earliest_height;
-      std::string status;
-      bool untrusted;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(version)
         KV_SERIALIZE(enabled)
         KV_SERIALIZE(window)
@@ -1806,8 +1801,6 @@ namespace cryptonote
         KV_SERIALIZE(voting)
         KV_SERIALIZE(state)
         KV_SERIALIZE(earliest_height)
-        KV_SERIALIZE(status)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1828,20 +1821,20 @@ namespace cryptonote
       END_KV_SERIALIZE_MAP()
     };
 
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
       std::vector<ban> bans;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(bans)
       END_KV_SERIALIZE_MAP()
     };
@@ -1865,22 +1858,21 @@ namespace cryptonote
       END_KV_SERIALIZE_MAP()
     };
 
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       std::vector<ban> bans;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
         KV_SERIALIZE(bans)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
-
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1915,22 +1907,21 @@ namespace cryptonote
 
   struct COMMAND_RPC_FLUSH_TRANSACTION_POOL
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       std::vector<std::string> txids;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
         KV_SERIALIZE(txids)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
-
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1938,7 +1929,7 @@ namespace cryptonote
 
   struct COMMAND_RPC_GET_OUTPUT_HISTOGRAM
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       std::vector<uint64_t> amounts;
       uint64_t min_count;
@@ -1947,6 +1938,7 @@ namespace cryptonote
       uint64_t recent_cutoff;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base);
         KV_SERIALIZE(amounts);
         KV_SERIALIZE(min_count);
         KV_SERIALIZE(max_count);
@@ -1975,16 +1967,13 @@ namespace cryptonote
       entry() {}
     };
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
-      std::string status;
       std::vector<entry> histogram;
-      bool untrusted;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(histogram)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -1992,25 +1981,23 @@ namespace cryptonote
 
   struct COMMAND_RPC_GET_VERSION
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
       uint32_t version;
       bool release;
-      bool untrusted;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(version)
         KV_SERIALIZE(release)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -2018,26 +2005,26 @@ namespace cryptonote
 
   struct COMMAND_RPC_GET_COINBASE_TX_SUM
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       uint64_t height;
       uint64_t count;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base);
         KV_SERIALIZE(height);
         KV_SERIALIZE(count);
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
-      std::string status;
       uint64_t emission_amount;
       uint64_t fee_amount;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(emission_amount)
         KV_SERIALIZE(fee_amount)
       END_KV_SERIALIZE_MAP()
@@ -2047,28 +2034,26 @@ namespace cryptonote
 
   struct COMMAND_RPC_GET_BASE_FEE_ESTIMATE
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       uint64_t grace_blocks;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
         KV_SERIALIZE(grace_blocks)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
-      std::string status;
       uint64_t fee;
       uint64_t quantization_mask;
-      bool untrusted;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(fee)
         KV_SERIALIZE_OPT(quantization_mask, (uint64_t)1)
-        KV_SERIALIZE(untrusted)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -2076,9 +2061,10 @@ namespace cryptonote
 
   struct COMMAND_RPC_GET_ALTERNATE_CHAINS
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
@@ -2106,13 +2092,12 @@ namespace cryptonote
       END_KV_SERIALIZE_MAP()
     };
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
       std::vector<chain_info> chains;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(chains)
       END_KV_SERIALIZE_MAP()
     };
@@ -2121,21 +2106,21 @@ namespace cryptonote
 
   struct COMMAND_RPC_UPDATE
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       std::string command;
       std::string path;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(command);
-        KV_SERIALIZE(path);
+        KV_SERIALIZE_PARENT(rpc_request_base)
+        KV_SERIALIZE(command)
+        KV_SERIALIZE(path)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
       bool update;
       std::string version;
       std::string user_uri;
@@ -2144,7 +2129,7 @@ namespace cryptonote
       std::string path;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(update)
         KV_SERIALIZE(version)
         KV_SERIALIZE(user_uri)
@@ -2158,22 +2143,21 @@ namespace cryptonote
 
   struct COMMAND_RPC_RELAY_TX
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       std::vector<std::string> txids;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
         KV_SERIALIZE(txids)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
-      std::string status;
-
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -2181,9 +2165,10 @@ namespace cryptonote
 
   struct COMMAND_RPC_SYNC_INFO
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
@@ -2218,9 +2203,8 @@ namespace cryptonote
       END_KV_SERIALIZE_MAP()
     };
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
-      std::string status;
       uint64_t height;
       uint64_t target_height;
       uint32_t next_needed_pruning_seed;
@@ -2229,7 +2213,7 @@ namespace cryptonote
       std::string overview;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(height)
         KV_SERIALIZE(target_height)
         KV_SERIALIZE(next_needed_pruning_seed)
@@ -2243,7 +2227,7 @@ namespace cryptonote
 
   struct COMMAND_RPC_GET_OUTPUT_DISTRIBUTION
   {
-    struct request_t
+    struct request_t: public rpc_access_request_base
     {
       std::vector<uint64_t> amounts;
       uint64_t from_height;
@@ -2253,6 +2237,7 @@ namespace cryptonote
       bool compress;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
         KV_SERIALIZE(amounts)
         KV_SERIALIZE_OPT(from_height, (uint64_t)0)
         KV_SERIALIZE_OPT(to_height, (uint64_t)0)
@@ -2305,16 +2290,213 @@ namespace cryptonote
       END_KV_SERIALIZE_MAP()
     };
 
-    struct response_t
+    struct response_t: public rpc_access_response_base
     {
-      std::string status;
       std::vector<distribution> distributions;
-      bool untrusted;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(distributions)
-        KV_SERIALIZE(untrusted)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<response_t> response;
+  };
+
+  struct COMMAND_RPC_ACCESS_INFO
+  {
+    struct request_t: public rpc_access_request_base
+    {
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<request_t> request;
+
+    struct response_t: public rpc_access_response_base
+    {
+      std::string hashing_blob;
+      uint64_t seed_height;
+      std::string seed_hash;
+      std::string next_seed_hash;
+      uint32_t cookie;
+      uint64_t diff;
+      uint64_t credits_per_hash_found;
+      uint64_t height;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
+        KV_SERIALIZE(hashing_blob)
+        KV_SERIALIZE(seed_height)
+        KV_SERIALIZE(seed_hash)
+        KV_SERIALIZE(next_seed_hash)
+        KV_SERIALIZE(cookie)
+        KV_SERIALIZE(diff)
+        KV_SERIALIZE(credits_per_hash_found)
+        KV_SERIALIZE(height)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<response_t> response;
+  };
+
+  struct COMMAND_RPC_ACCESS_SUBMIT_NONCE
+  {
+    struct request_t: public rpc_access_request_base
+    {
+      uint32_t nonce;
+      uint32_t cookie;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
+        KV_SERIALIZE(nonce)
+        KV_SERIALIZE(cookie)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<request_t> request;
+
+    struct response_t: public rpc_access_response_base
+    {
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<response_t> response;
+  };
+
+  struct COMMAND_RPC_ACCESS_PAY
+  {
+    struct request_t: public rpc_access_request_base
+    {
+      std::string paying_for;
+      uint64_t payment;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
+        KV_SERIALIZE(paying_for)
+        KV_SERIALIZE(payment)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<request_t> request;
+
+    struct response_t: public rpc_access_response_base
+    {
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<response_t> response;
+  };
+
+  struct COMMAND_RPC_ACCESS_TRACKING
+  {
+    struct request_t: public rpc_request_base
+    {
+      bool clear;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
+        KV_SERIALIZE(clear)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<request_t> request;
+
+    struct entry
+    {
+      std::string rpc;
+      uint64_t count;
+      uint64_t time;
+      uint64_t credits;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(rpc)
+        KV_SERIALIZE(count)
+        KV_SERIALIZE(time)
+        KV_SERIALIZE(credits)
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response_t: public rpc_response_base
+    {
+      std::vector<entry> data;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_response_base)
+        KV_SERIALIZE(data)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<response_t> response;
+  };
+
+  struct COMMAND_RPC_ACCESS_DATA
+  {
+    struct request_t: public rpc_request_base
+    {
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<request_t> request;
+
+    struct entry
+    {
+      std::string client;
+      uint64_t balance;
+      uint64_t last_update_time;
+      uint64_t credits_total;
+      uint64_t credits_used;
+      uint64_t nonces_good;
+      uint64_t nonces_stale;
+      uint64_t nonces_bad;
+      uint64_t nonces_dupe;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(client)
+        KV_SERIALIZE(balance)
+        KV_SERIALIZE(last_update_time)
+        KV_SERIALIZE(credits_total)
+        KV_SERIALIZE(credits_used)
+        KV_SERIALIZE(nonces_good)
+        KV_SERIALIZE(nonces_stale)
+        KV_SERIALIZE(nonces_bad)
+        KV_SERIALIZE(nonces_dupe)
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response_t: public rpc_response_base
+    {
+      std::list<entry> entries;
+      uint32_t hashrate;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_response_base)
+        KV_SERIALIZE(entries)
+        KV_SERIALIZE(hashrate)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<response_t> response;
+  };
+
+  struct COMMAND_RPC_ACCESS_ACCOUNT
+  {
+    struct request_t: public rpc_request_base
+    {
+      std::string client;
+      int64_t delta_balance;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
+        KV_SERIALIZE(client)
+        KV_SERIALIZE_OPT(delta_balance, (int64_t)0)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<request_t> request;
+
+    struct response_t: public rpc_response_base
+    {
+      uint64_t credits;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_response_base)
+        KV_SERIALIZE(credits)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;
@@ -2322,23 +2504,23 @@ namespace cryptonote
 
   struct COMMAND_RPC_POP_BLOCKS
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       uint64_t nblocks;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(nblocks);
+        KV_SERIALIZE_PARENT(rpc_request_base)
+        KV_SERIALIZE(nblocks)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response_t
+    struct response_t: public rpc_response_base
     {
-      std::string status;
       uint64_t height;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(status)
+        KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(height)
       END_KV_SERIALIZE_MAP()
     };
@@ -2347,26 +2529,49 @@ namespace cryptonote
 
   struct COMMAND_RPC_PRUNE_BLOCKCHAIN
   {
-    struct request_t
+    struct request_t: public rpc_request_base
     {
       bool check;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_request_base)
         KV_SERIALIZE_OPT(check, false)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<request_t> request;
+
+    struct response_t: public rpc_response_base
+    {
+      bool pruned;
+      uint32_t pruning_seed;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_response_base)
+        KV_SERIALIZE(pruned)
+        KV_SERIALIZE(pruning_seed)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<response_t> response;
+  };
+
+  struct COMMAND_RPC_FLUSH_CACHE
+  {
+    struct request_t
+    {
+      bool bad_txs;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_OPT(bad_txs, false)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
     struct response_t
     {
-      bool pruned;
-      uint32_t pruning_seed;
       std::string status;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(status)
-        KV_SERIALIZE(pruned)
-        KV_SERIALIZE(pruning_seed)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;

--- a/wallet/wallet_errors.h
+++ b/wallet/wallet_errors.h
@@ -90,6 +90,7 @@ namespace tools
     //         is_key_image_spent_error
     //         get_histogram_error
     //         get_output_distribution
+    //         payment_required
     //       wallet_files_doesnt_correspond
     //
     // * - class with protected ctor
@@ -781,6 +782,20 @@ namespace tools
       const std::string m_status;
     };
     //----------------------------------------------------------------------------------------------------
+    struct wallet_coded_rpc_error : public wallet_rpc_error
+    {
+      explicit wallet_coded_rpc_error(std::string&& loc, const std::string& request, int code, const std::string& status)
+        : wallet_rpc_error(std::move(loc), std::string("error ") + std::to_string(code) + (" in ") + request + " RPC: " + status, request),
+        m_code(code), m_status(status)
+      {
+      }
+      int code() const { return m_code; }
+      const std::string& status() const { return m_status; }
+    private:
+      int m_code;
+      const std::string m_status;
+    };
+    //----------------------------------------------------------------------------------------------------
     struct daemon_busy : public wallet_rpc_error
     {
       explicit daemon_busy(std::string&& loc, const std::string& request)
@@ -817,6 +832,14 @@ namespace tools
     {
       explicit get_output_distribution(std::string&& loc, const std::string& request)
         : wallet_rpc_error(std::move(loc), "failed to get output distribution", request)
+      {
+      }
+    };
+    //----------------------------------------------------------------------------------------------------
+    struct payment_required: public wallet_rpc_error
+    {
+      explicit payment_required(std::string&& loc, const std::string& request)
+        : wallet_rpc_error(std::move(loc), "payment required", request)
       {
       }
     };

--- a/wallet/wallet_rpc_server_commands_defs.h
+++ b/wallet/wallet_rpc_server_commands_defs.h
@@ -47,7 +47,7 @@
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define WALLET_RPC_VERSION_MAJOR 1
-#define WALLET_RPC_VERSION_MINOR 15
+#define WALLET_RPC_VERSION_MINOR 16
 #define MAKE_WALLET_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define WALLET_RPC_VERSION MAKE_WALLET_RPC_VERSION(WALLET_RPC_VERSION_MAJOR, WALLET_RPC_VERSION_MINOR)
 namespace tools
@@ -1840,6 +1840,38 @@ namespace wallet_rpc
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(index);
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<response_t> response;
+  };
+
+  struct COMMAND_RPC_EDIT_ADDRESS_BOOK_ENTRY
+  {
+    struct request_t
+    {
+      uint64_t index;
+      bool set_address;
+      std::string address;
+      bool set_payment_id;
+      std::string payment_id;
+      bool set_description;
+      std::string description;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(index)
+        KV_SERIALIZE(set_address)
+        KV_SERIALIZE(address)
+        KV_SERIALIZE(set_payment_id)
+        KV_SERIALIZE(payment_id)
+        KV_SERIALIZE(set_description)
+        KV_SERIALIZE(description)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<request_t> request;
+
+    struct response_t
+    {
+      BEGIN_KV_SERIALIZE_MAP()
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;


### PR DESCRIPTION
Update to the last common ancestor of the upstream Monero `master` and `release-v0.15` branch.

A couple of functions that appear to be unused by `mymonero-core-cpp` (`test_all` builds and runs without them) have been removed. Otherwise they would require a couple of functions from RandomX and epee to be imported.

